### PR TITLE
Teammates contribution 2.5.24

### DIFF
--- a/src/web/app/components/copy-course-modal/__snapshots__/copy-course-modal.component.spec.ts.snap
+++ b/src/web/app/components/copy-course-modal/__snapshots__/copy-course-modal.component.spec.ts.snap
@@ -67,6 +67,17 @@ exports[`CopyCourseModalComponent should snap when copying from other sessions 1
             placeholder="e.g. CS3215-2013Semester1"
             type="text"
           />
+          <div
+              class="invalid-field"
+              hidden=""
+            >
+              <i
+                aria-hidden="true"
+                class="fa fa-exclamation-circle"
+              />
+               The field Course ID should not be empty. 
+            </div>
+          </div>
           <span>
             64 characters left
           </span>
@@ -84,6 +95,17 @@ exports[`CopyCourseModalComponent should snap when copying from other sessions 1
             placeholder="e.g. Software Engineering"
             type="text"
           />
+          <div
+              class="invalid-field"
+              hidden=""
+            >
+              <i
+                aria-hidden="true"
+                class="fa fa-exclamation-circle"
+              />
+               The field Course Name should not be empty. 
+            </div>
+          </div>
           <span>
             80 characters left
           </span>

--- a/src/web/app/components/copy-course-modal/__snapshots__/copy-course-modal.component.spec.ts.snap
+++ b/src/web/app/components/copy-course-modal/__snapshots__/copy-course-modal.component.spec.ts.snap
@@ -65,18 +65,18 @@ exports[`CopyCourseModalComponent should snap when copying from other sessions 1
             id="copy-course-id"
             maxlength="64"
             placeholder="e.g. CS3215-2013Semester1"
+            required=""
             type="text"
           />
           <div
-              class="invalid-field"
-              hidden=""
-            >
-              <i
-                aria-hidden="true"
-                class="fa fa-exclamation-circle"
-              />
-               The field Course ID should not be empty. 
-            </div>
+            class="invalid-field"
+            hidden=""
+          >
+            <i
+              aria-hidden="true"
+              class="fa fa-exclamation-circle"
+            />
+             The field Course ID should not be empty.
           </div>
           <span>
             64 characters left
@@ -93,18 +93,18 @@ exports[`CopyCourseModalComponent should snap when copying from other sessions 1
             id="copy-course-name"
             maxlength="80"
             placeholder="e.g. Software Engineering"
+            required=""
             type="text"
           />
           <div
-              class="invalid-field"
-              hidden=""
-            >
-              <i
-                aria-hidden="true"
-                class="fa fa-exclamation-circle"
-              />
-               The field Course Name should not be empty. 
-            </div>
+            class="invalid-field"
+            hidden=""
+          >
+            <i
+              aria-hidden="true"
+              class="fa fa-exclamation-circle"
+            />
+             The field Course Name should not be empty.
           </div>
           <span>
             80 characters left


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

**PR title**: [#12653] Copy course modal: Mandatory fields not highlighted

**Fixes #**
#12653

**Outline of Solution**

To resolve the issue, I made some changes in the html for copy course modal. Using the alert message HTML code found in the course edit form html, I added some necessary attributes one of which is shown below and "required" which is shown in the input section. The previous PR had missing attributes so this resolved that.
![image](https://github.com/shiishorts/teammates/assets/116765932/e903b40a-7396-4528-8151-26d3051e034d)

